### PR TITLE
Fix Blender template to allow bugfix versions (i.e. 2.77a, 2.78a, etc).

### DIFF
--- a/Blender.xml.template
+++ b/Blender.xml.template
@@ -13,27 +13,27 @@
   <group license="GPL v2 (GNU General Public License)">
     <implementation arch="Windows-x86_64" version="{version}" released="{released}" stability="stable" main="blender.exe">
       <manifest-digest />
-      <archive href="http://download.blender.org/release/Blender{build}/blender-{build}-windows64.zip" type="application/zip" extract="blender-{build}-windows64" />
+      <archive href="http://download.blender.org/release/Blender{versionshort}/blender-{versionreal}-windows64.zip" type="application/zip" extract="blender-{versionreal}-windows64" />
     </implementation>
     <implementation arch="Windows-i486" version="{version}" released="{released}" stability="stable" main="blender.exe">
       <manifest-digest />
-      <archive href="http://download.blender.org/release/Blender{build}/blender-{build}-windows32.zip" type="application/zip" extract="blender-{build}-windows32" />
+      <archive href="http://download.blender.org/release/Blender{versionshort}/blender-{versionreal}-windows32.zip" type="application/zip" extract="blender-{versionreal}-windows32" />
     </implementation>
     <implementation arch="Linux-x86_64" version="{version}" released="{released}" stability="stable" main="blender">
       <manifest-digest />
-      <archive href="http://download.blender.org/release/Blender{build}/blender-{build}-linux-glibc211-x86_64.tar.bz2" type="application/x-bzip-compressed-tar" extract="blender-{build}-linux-glibc211-x86_64" />
+      <archive href="http://download.blender.org/release/Blender{versionshort}/blender-{versionreal}-linux-glibc211-x86_64.tar.bz2" type="application/x-bzip-compressed-tar" extract="blender-{versionreal}-linux-glibc211-x86_64" />
     </implementation>
     <implementation arch="Linux-i686" version="{version}" released="{released}" stability="stable" main="blender">
       <manifest-digest />
-      <archive href="http://download.blender.org/release/Blender{build}/blender-{build}-linux-glibc211-i686.tar.bz2" type="application/x-bzip-compressed-tar" extract="blender-{build}-linux-glibc211-i686" />
+      <archive href="http://download.blender.org/release/Blender{versionshort}/blender-{versionreal}-linux-glibc211-i686.tar.bz2" type="application/x-bzip-compressed-tar" extract="blender-{versionreal}-linux-glibc211-i686" />
     </implementation>
     <!--<implementation arch="MacOSX-x86_64" version="{version}" released="{released}" stability="stable" main="blender.app/Contents/MacOS/blender">
       <manifest-digest />
-      <archive href="http://download.blender.org/release/Blender{build}/blender-{build}-OSX_10.6-x86_64.zip" type="application/zip" extract="Blender" />
+      <archive href="http://download.blender.org/release/Blender{versionshort}/blender-{versionreal}-OSX_10.6-x86_64.zip" type="application/zip" extract="Blender" />
     </implementation>
     <implementation arch="MacOSX-i386" version="{version}" released="{released}" stability="stable" main="blender.app/Contents/MacOS/blender">
       <manifest-digest />
-      <archive href="http://download.blender.org/release/Blender{build}/blender-{build}-OSX_10.6-fix-i386.zip" type="application/zip" extract="Blender" />
+      <archive href="http://download.blender.org/release/Blender{versionshort}/blender-{versionreal}-OSX_10.6-fix-i386.zip" type="application/zip" extract="Blender" />
     </implementation>-->
   </group>
 </interface>


### PR DESCRIPTION
The version number with letter suffix represents a bugfix version next to official release.

Since this Blender's version numbering is not fits into version specification of 0install (http://0install.net/interface-spec.html#versions), so we have to give a different version number for XML. Thus, the 0template script is intended to be invoked as follows:
- 0template Blender.xml.template version=2.77 versionreal=2.77 versionshort=2.77 released=2016-04-062016-03-18 #for first stable release
- 0template Blender.xml.template version=2.77.1 versionreal=2.77a versionshort=2.77  #for bugfix release